### PR TITLE
BUG: DesignTile Not Using DefaultImage [Finishes #158912296]

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ This is a wrapper around flex box with column layout
 
 
 ## `<DesignCollection />`
-This component shows a collection of `<DesignTile />`. This component is being inside `<Store />` component but if applications needs to show a collection of designs somewhere else, this could be used.
+This component shows a collection of `<DesignTile />`. This component is being used inside `<Store />` component but if applications needs to show a collection of designs somewhere else, this could be used.
 
 #### `<DesignCollection />` propTypes
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teepublic-react",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "TeePublic React Components",
   "main": "build/index.js",
   "scripts": {

--- a/src/lib/components/design_tile/DesignTile.js
+++ b/src/lib/components/design_tile/DesignTile.js
@@ -20,18 +20,14 @@ export default class DesignTile extends Component {
 
     const classes = classnames(CLASS_ROOT, className, 'teepublic');
 
-    const { images, price } = designSku;
-
-    var skuMockupImage = _.find(images, function(image) {
-      return image.type === 'mockup';
-    });
+    const { defaultImage, price } = designSku;
 
     const designImage = (
       <a href={buyProductLink} className={`${CLASS_ROOT}__image-link`}>
         <img
           className={`${CLASS_ROOT}__image`}
-          src={skuMockupImage.url}
-          alt={skuMockupImage.type}
+          src={defaultImage.url}
+          alt={defaultImage.type}
         />
       </a>
     );


### PR DESCRIPTION
Products that did not have mockup images were breaking the storefront.

* Change `DesignTile` to use `defaultImage` as the display image instead of always looking for a `mockup`.