### PR TITLE
Don't show the variants box when there's no variants

### DIFF
--- a/src/lib/components/product_variants/ProductVariants.js
+++ b/src/lib/components/product_variants/ProductVariants.js
@@ -49,14 +49,14 @@ export default class ProductVariants extends Component {
       );
     }, this);
 
-    return (
+    return variants.length ? (
       <div className={classes}>
         <h3 className={`${CLASS_ROOT}__h`}>
           This product is also available as:
         </h3>
         <div className={`${CLASS_ROOT}__thumbs`}>{variants}</div>
       </div>
-    );
+    ) : null;
   }
 }
 


### PR DESCRIPTION
When no variants are present, there was a confusing "This product is also available as" header with nothing following it.
WDYT?