### PR TITLE
FEATURE: Add to cart callback.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teepublic-react",
-  "version": "0.4.22",
+  "version": "0.5.0",
   "description": "TeePublic React Components",
   "main": "build/index.js",
   "scripts": {

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -76,6 +76,7 @@ export default class App extends Component {
             return `${baseUrl}/${type}/${tag}?ref_id=${affiliateId}&aff_network_id=${affiliateNetworkId}`;
           }}
           sizechartUrl={ROUTE_CONFIGURATION.sizechartUrl()}
+          cartAddCallback={ROUTE_CONFIGURATION.cartAddCallback}
         />
         <br />
         <br />

--- a/src/demo/RouteConfiguration.js
+++ b/src/demo/RouteConfiguration.js
@@ -26,5 +26,9 @@ export const ROUTE_CONFIGURATION = {
 
   sizechartUrl: () => {
     return 'https://www.teepublic.com/sizechart';
+  },
+
+  cartAddCallback: () => {
+    window.location = '/cart';
   }
 };

--- a/src/lib/components/add_to_cart/AddToCart.js
+++ b/src/lib/components/add_to_cart/AddToCart.js
@@ -15,10 +15,19 @@ export default class AddToCart extends Component {
       sku,
       storeId,
       affiliateId,
-      affiliateNetworkId
+      affiliateNetworkId,
+      callback
     } = this.props;
     const cartHelper = new CartHelper();
-    cartHelper.addToCart(design, sku, storeId, affiliateId, affiliateNetworkId);
+
+    cartHelper.addToCart(
+      design,
+      sku,
+      storeId,
+      affiliateId,
+      affiliateNetworkId,
+      callback
+    );
   };
 
   render() {
@@ -43,5 +52,6 @@ AddToCart.propTypes = {
   affiliateId: PropTypes.number.isRequired,
   affiliateNetworkId: PropTypes.number.isRequired,
   storeId: PropTypes.number.isRequired,
-  sku: PropTypes.object.isRequired
+  sku: PropTypes.object.isRequired,
+  callback: PropTypes.func
 };

--- a/src/lib/components/buy_product/BuyProduct.js
+++ b/src/lib/components/buy_product/BuyProduct.js
@@ -23,6 +23,7 @@ export default class BuyProduct extends Component {
     const productOptions = props.skuData.options;
     const skus = props.skuData._embedded.skus;
     const colorMetaData = props.skuData._embedded.colors;
+    const cartAddCallback = props.cartAddCallback;
 
     this.productHelper = new ProductHelper();
     const selectorsOptions = this.productHelper.collectSelectorOptions(
@@ -95,7 +96,8 @@ export default class BuyProduct extends Component {
       buyProductLinkBuilder,
       tagLinkBuilder,
       affiliateNetworkId,
-      sizechartUrl
+      sizechartUrl,
+      cartAddCallback
     } = this.props;
 
     const {
@@ -142,6 +144,7 @@ export default class BuyProduct extends Component {
         storeId={store.id}
         affiliateId={store.affiliateId}
         affiliateNetworkId={affiliateNetworkId}
+        callback={cartAddCallback}
       />
     );
 

--- a/src/lib/utils/CartHelper.js
+++ b/src/lib/utils/CartHelper.js
@@ -6,6 +6,7 @@ export default class CartHelper {
     storeId,
     affiliateId,
     affiliateNetworkId,
+    callback,
     quantity = 1
   ) {
     const addedCartItem = {
@@ -32,7 +33,7 @@ export default class CartHelper {
       cartItems.push(addedCartItem);
     }
 
-    this.setCartItems(cartItems);
+    this.setCartItems(cartItems, callback);
   }
 
   updateCartItem(updatedCartItem) {
@@ -85,8 +86,9 @@ export default class CartHelper {
     }
   }
 
-  setCartItems(cartItems) {
+  setCartItems(cartItems, callback) {
     localStorage.setItem(CART_KEY, JSON.stringify(cartItems));
+    if (callback) callback();
   }
 
   itemsDescription(cartItems) {


### PR DESCRIPTION
@monteverdetico This should probably be a minor version bump because adding the callback as a param to `cartHelper.addToCart` would blow things where `quantity` was being passed (it's optional and defaults to 1).

(Really a major version bump would be ideal, but let's keep it in beta (0).

https://github.com/BustedTees/teepublic-react/compare/feature/add-to-cart-callback?expand=1#diff-2a6c19fe787ca87caf014e6c9d9998caR9